### PR TITLE
Prepare the worker for docker images

### DIFF
--- a/src/downloadNewDataFromURL/Dockerfile
+++ b/src/downloadNewDataFromURL/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:alpine
+
+RUN apk update && apk add bash
+COPY ./package.json ./package-lock.json ./home/
+WORKDIR /home
+RUN npm install 
+COPY ./src/downloadNewDataFromURL/index.js .
+CMD ["node", "./index.js"]

--- a/src/downloadNewDataFromURL/Dockerfile
+++ b/src/downloadNewDataFromURL/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:alpine
 
-RUN apk update && apk add bash
 COPY ./package.json ./package-lock.json ./home/
 WORKDIR /home
 RUN npm install 

--- a/src/downloadNewDataFromURL/README.md
+++ b/src/downloadNewDataFromURL/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Run `docker build -f src/downloadNewDataFromURL/Dockerfile -t nexus.terrestris.de/terrestris/mqm-worker/download-new-data-from-url .` from `./rabbitmq-worker`

--- a/src/downloadNewDataFromURL/index.js
+++ b/src/downloadNewDataFromURL/index.js
@@ -6,7 +6,7 @@ const https = require('https');
 const amqp = require('amqplib');
 const { worker } = require('cluster');
 
-const dir = '../data';
+const dir = '/home/data';
 
 const downloadNewDataFromURL = (uri) => {
   const url = new URL(uri);
@@ -29,7 +29,7 @@ const logAndExit = (msg) => {
 
 (async function main() {
   const connection = await amqp
-    .connect('amqp://localhost', 'heartbeat=60')
+    .connect('amqp://rabbitmq', 'heartbeat=60')
     .catch(logAndExit);
   const channel = await connection.createChannel().catch(logAndExit);
   const downloadQueue = 'download';

--- a/src/gunzipFile/Dockerfile
+++ b/src/gunzipFile/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:alpine
 
-RUN apk update && apk add bash
 COPY ./package.json ./package-lock.json ./home/
 WORKDIR /home
 RUN npm install 

--- a/src/gunzipFile/Dockerfile
+++ b/src/gunzipFile/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:alpine
+
+RUN apk update && apk add bash
+COPY ./package.json ./package-lock.json ./home/
+WORKDIR /home
+RUN npm install 
+COPY ./src/gunzipFile/index.js .
+CMD ["node", "./index.js"]

--- a/src/gunzipFile/README.md
+++ b/src/gunzipFile/README.md
@@ -1,0 +1,3 @@
+# Readme
+
+Run `docker build -f src/gunzipFile/Dockerfile -t nexus.terrestris.de/terrestris/mqm-worker/gunzip-file .` from `./rabbitmq-worker`

--- a/src/gunzipFile/index.js
+++ b/src/gunzipFile/index.js
@@ -38,7 +38,7 @@ const gunzipDownloadedFile = (file) => {
 
 (async function main() {
   const connection = await amqp
-    .connect('amqp://localhost', 'heartbeat=60')
+    .connect('amqp://rabbitmq', 'heartbeat=60')
     .catch(logAndExit);
   const channel = await connection.createChannel().catch(logAndExit);
   const extractQueue = 'extract';


### PR DESCRIPTION
This PR 

- is used to prepare the existing workers `downloadNewDataFromURL` and `gunzipFile` as Docker images.

**Note**: 
- the amqp connection is changed here from `localhost` to `rabbitmq` (name of RabbitMQ service via docker-compose file)
- see the README files of the workers to build the images

The GitHub action to build and publish the images will be part of another PR.

@JakobMiksch @weskamm please note, will merge soon if there are no objections