### PR TITLE
Make workers use custom credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ download-new-data-from-url:
         - ../data:/home/data:Z
     depends_on:
         - rabbitmq
+    environment:
+      - RABBITHOST=rabbitmq
+      - RABBITUSER=username
+      - RABBITPASS=password
+      - WORKERQUEUE=download-new-data-from-url
+      - RESULTSQUEUE=results
 ```
 
 Via the mounted directory (`data`) the downloaded files are stored and processed if necessary.

--- a/src/download-new-data-from-url/index.js
+++ b/src/download-new-data-from-url/index.js
@@ -4,9 +4,11 @@ import request from 'request';
 
 import { initialize, errorAndExit, log } from '../workerTemplate.js';
 const dir = '/home/data';
-const workerQueue = 'download';
-const resultQueue = 'results';
-const rabbitHost = 'amqp://rabbitmq';
+const workerQueue = process.env.WORKERQUEUE;
+const resultQueue = process.env.RESULTSQUEUE;
+const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 
 /**
  * Downloads data for the given URL.
@@ -43,4 +45,4 @@ const downloadNewDataFromURL = async(workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, downloadNewDataFromURL);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, downloadNewDataFromURL);

--- a/src/geonetwork-publish-metadata/index.js
+++ b/src/geonetwork-publish-metadata/index.js
@@ -7,6 +7,8 @@ const pw = process.env.GNPASS;
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 const gnos = new GeoNetworkClient(url, user, pw);
 
 /**
@@ -51,4 +53,4 @@ const geonetworkPublishMetdata = async(workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, geonetworkPublishMetdata);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, geonetworkPublishMetdata);

--- a/src/geoserver-publish-layer-from-db/index.js
+++ b/src/geoserver-publish-layer-from-db/index.js
@@ -7,6 +7,8 @@ const pw = process.env.GSPASS;
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 const grc = new GeoServerRestClient(url, user, pw);
 
 /**
@@ -73,4 +75,4 @@ const geoserverPublishLayerFromDb = async(workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, geoserverPublishLayerFromDb);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, geoserverPublishLayerFromDb);

--- a/src/geoserver-publish-sld/index.js
+++ b/src/geoserver-publish-sld/index.js
@@ -7,6 +7,8 @@ const pw = process.env.GSPASS;
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 const grc = new GeoServerRestClient(url, user, pw);
 
 /**
@@ -68,4 +70,4 @@ const geoserverPublishSLD = async(workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, geoserverPublishSLD);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, geoserverPublishSLD);

--- a/src/gunzip-file/index.js
+++ b/src/gunzip-file/index.js
@@ -2,9 +2,11 @@ import zlib from 'zlib';
 import fs from 'fs';
 import { initialize, log, errorAndExit } from '../workerTemplate.js';
 
-const workerQueue = 'extract';
-const resultQueue = 'results';
-const rabbitHost = 'amqp://rabbitmq';
+const workerQueue = process.env.WORKERQUEUE;
+const resultQueue = process.env.RESULTSQUEUE;
+const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 
 /**
  * Extracts a given `*.gz` file.
@@ -49,4 +51,4 @@ const gunzipDownloadedFile = async(workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, gunzipDownloadedFile);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, gunzipDownloadedFile);

--- a/src/send-email/index.js
+++ b/src/send-email/index.js
@@ -4,6 +4,8 @@ import { log, initialize, errorAndExit } from '../workerTemplate.js';
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
+const rabbitUser = process.env.RABBITUSER;
+const rabbitPass = process.env.RABBITPASS;
 const mailHost = process.env.MAILHOST;
 const mailPort = process.env.MAILPORT;
 const secure = process.env.SECURE === 'true' ? true : false;
@@ -65,4 +67,4 @@ const sendEmail = async (workerJob, inputs) => {
 };
 
 // Initialize and start the worker process
-initialize(rabbitHost, workerQueue, resultQueue, sendEmail);
+initialize(rabbitHost, rabbitUser, rabbitPass, workerQueue, resultQueue, sendEmail);


### PR DESCRIPTION
This is a follow up of https://github.com/klips-project/rabbitmq-worker/pull/24 and makes the worker use configured credentials.

@mholthausen please review