### PR TITLE
Remove not needed CLI args

### DIFF
--- a/src/dispatcher/Dockerfile
+++ b/src/dispatcher/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/dispatcher/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js"]

--- a/src/download-new-data-from-url/Dockerfile
+++ b/src/download-new-data-from-url/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/download-new-data-from-url/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js"]

--- a/src/geonetwork-publish-metadata/Dockerfile
+++ b/src/geonetwork-publish-metadata/Dockerfile
@@ -9,8 +9,8 @@ ENV RESULTSQUEUE results
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/geonetwork-publish-metadata/index.js worker/
 COPY src/workerTemplate.js .
 COPY src/gnos-client.js .
-CMD ["sh", "-c", "node worker/index.js ${GNHOST} ${GNUSER} ${GNPASS} ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js ${GNHOST} ${GNUSER} ${GNPASS}"]

--- a/src/geoserver-publish-layer-from-db/Dockerfile
+++ b/src/geoserver-publish-layer-from-db/Dockerfile
@@ -9,7 +9,7 @@ ENV RESULTSQUEUE results
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/geoserver-publish-layer-from-db/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS} ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS}"]

--- a/src/geoserver-publish-sld/Dockerfile
+++ b/src/geoserver-publish-sld/Dockerfile
@@ -9,7 +9,7 @@ ENV RESULTSQUEUE results
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/geoserver-publish-sld/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS} ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS}"]

--- a/src/gunzip-file/Dockerfile
+++ b/src/gunzip-file/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/gunzip-file/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js"]

--- a/src/send-email/Dockerfile
+++ b/src/send-email/Dockerfile
@@ -13,7 +13,7 @@ ENV RESULTSQUEUE results
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/send-email/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${MAILHOST} ${MAILPORT} ${SECURE} ${AUTHUSER} ${AUTHPASS} ${FROMSENDERNAME} ${FROMSENDEREMAIL} ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js ${MAILHOST} ${MAILPORT} ${SECURE} ${AUTHUSER} ${AUTHPASS} ${FROMSENDERNAME} ${FROMSENDEREMAIL}"]

--- a/src/upload-file/Dockerfile
+++ b/src/upload-file/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/upload-file/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js"]

--- a/src/zip-handler/Dockerfile
+++ b/src/zip-handler/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 COPY ./package.json ./package-lock.json /home/
 WORKDIR /home/
-RUN npm install 
+RUN npm install
 COPY src/zip-handler/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${RABBITHOST} ${RABBITUSER} ${RABBITPASS} ${WORKERQUEUE} ${RESULTQUEUE}"]
+CMD ["sh", "-c", "node worker/index.js"]


### PR DESCRIPTION
Remove commadline arguments in the Docker CMD scripts, because they are not needed. 