### PR TITLE
Worker: Publish GeoTIFF to GeoServer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,13 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "rabbitmq-worker",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "amqplib": "^0.8.0",
         "archiver": "^5.3.0",
         "form-data": "^4.0.0",
-        "geoserver-node-client": "0.0.2",
+        "geoserver-node-client": "0.0.5",
         "node-fetch": "^2.6.1",
         "nodemailer": "^6.6.2",
         "request": "^2.88.2",
@@ -1210,9 +1209,9 @@
       "dev": true
     },
     "node_modules/geoserver-node-client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.2.tgz",
-      "integrity": "sha512-sgfpMaHzVNAaB/vt4nxb71DGD+3TnSrJhBQv0eSqnyj0SHZixt8ZllmbRvtBBdOq8ui+jcxHebkdUM1sJdixhg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.5.tgz",
+      "integrity": "sha512-uKcnO2I74eqR+5LZGcelv3/vKG6WpcXOrKAG1x60hq+RjGA/kLdSX0Fw5B1cnlzunFRmokNhLNchW1kVcmYXig==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -3368,9 +3367,9 @@
       "dev": true
     },
     "geoserver-node-client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.2.tgz",
-      "integrity": "sha512-sgfpMaHzVNAaB/vt4nxb71DGD+3TnSrJhBQv0eSqnyj0SHZixt8ZllmbRvtBBdOq8ui+jcxHebkdUM1sJdixhg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/geoserver-node-client/-/geoserver-node-client-0.0.5.tgz",
+      "integrity": "sha512-uKcnO2I74eqR+5LZGcelv3/vKG6WpcXOrKAG1x60hq+RjGA/kLdSX0Fw5B1cnlzunFRmokNhLNchW1kVcmYXig==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "amqplib": "^0.8.0",
     "archiver": "^5.3.0",
     "form-data": "^4.0.0",
-    "geoserver-node-client": "0.0.2",
+    "geoserver-node-client": "0.0.5",
     "node-fetch": "^2.6.1",
     "nodemailer": "^6.6.2",
     "request": "^2.88.2",

--- a/src/geoserver-publish-geotiff/Dockerfile
+++ b/src/geoserver-publish-geotiff/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:alpine
+
+COPY ./package.json ./package-lock.json /home/
+WORKDIR /home/
+RUN npm install
+COPY src/geoserver-publish-geotiff/index.js worker/
+COPY src/workerTemplate.js .
+CMD ["sh", "-c", "node worker/index.js"]

--- a/src/geoserver-publish-geotiff/index.js
+++ b/src/geoserver-publish-geotiff/index.js
@@ -9,6 +9,7 @@ const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
 const rabbitUser = process.env.RABBITUSER;
 const rabbitPass = process.env.RABBITPASS;
+
 const grc = new GeoServerRestClient(url, user, pw);
 
 /**
@@ -17,10 +18,10 @@ const grc = new GeoServerRestClient(url, user, pw);
  * @param {Object} workerJob The job object
  * @param {Array} inputs The inputs for this process
  *   First input is the workspace to publish to
- *   Second Input is the name of the created datastore
- *   Third Input is the the name of the created layer
- *   Fourth Input is the title of the created layer
- *   Fifth Input is the local path where the GeoTIFF is located
+ *   Second input is the name of the created datastore
+ *   Third input is the the name of the created layer
+ *   Fourth input is the title of the created layer
+ *   Fifth input is the local path where the GeoTIFF is located
  * @example
     {
        "id": 123,

--- a/src/packagesToBuild.json
+++ b/src/packagesToBuild.json
@@ -1,1 +1,1 @@
-["download-new-data-from-url","gunzip-file","geoserver-publish-sld","geoserver-publish-layer-from-db","geonetwork-publish-metadata","send-email","dispatcher","zip-handler","upload-file"]
+["download-new-data-from-url","gunzip-file","geoserver-publish-sld","geoserver-publish-layer-from-db","geonetwork-publish-metadata","send-email","dispatcher","zip-handler","upload-file", "geoserver-publish-geotiff"]


### PR DESCRIPTION
Add a worker that publishes a GeoTIFF to GeoServer. 

Sample job:
```json
    {
       "id": 123,
       "type": "geoserver-publish-geotiff",
       "inputs": [
           "klips",
           "my-datastore",
           "my-name",
           "my-title",
           "/path/to/the/GeoTiff.tif"
        ]
    }
```

**NOTE**: This worker uses `geoserver-node-client` in `v0.5.0`. The other workers that use that library used it in version `v0.2.0`. This might break their functionality. This might be fixed by the approach of @weskamm to have a separate `package.json` in each worker