### PR TITLE
geoserver-publish-geotiff: upgrade `geoserver-node-client`

### DIFF
--- a/src/geoserver-publish-geotiff/index.js
+++ b/src/geoserver-publish-geotiff/index.js
@@ -1,4 +1,4 @@
-import GeoServerRestClient from 'geoserver-node-client/geoserver-rest-client.js';
+import { GeoServerRestClient } from 'geoserver-node-client';
 import { log, initialize } from '../workerTemplate.js';
 
 const url = process.env.GEOSERVER_REST_URL;
@@ -43,18 +43,14 @@ const geoserverPublishGeoTiff = async (workerJob, inputs) => {
   const layerTitle = inputs[3];
   const geoTiffPath = inputs[4];
 
-  const gsExists = await grc.exists();
-  if (!gsExists) {
-    throw 'GeoServer not found';
-  }
-
-  const geotiffCreated = await grc.datastores.createGeotiffFromFile(
-    workspace, dataStore, layerName, layerTitle, geoTiffPath
-  );
-
-  if (geotiffCreated) {
+  try {
+    await grc.about.exists();
+    await grc.datastores.createGeotiffFromFile(
+      workspace, dataStore, layerName, layerTitle, geoTiffPath
+    );
     log('Successfully published GeoTIFF');
-  } else {
+  } catch (error) {
+    log(error)
     throw 'Could not publish GeoTIFF';
   }
 

--- a/src/geoserver-publish-geotiff/package.json
+++ b/src/geoserver-publish-geotiff/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "amqplib": "^0.8.0",
-    "geoserver-node-client": "0.0.7"
+    "geoserver-node-client": "1.1.0"
   },
   "devDependencies": {
     "eslint": "^7.29.0"


### PR DESCRIPTION
Upgrades `geoserver-node-client` to `1.1.0`. In includes a breaking change of the library.