### PR TITLE
Start workers after RabbitMQ is available

### DIFF
--- a/src/dispatcher/Dockerfile
+++ b/src/dispatcher/Dockerfile
@@ -1,8 +1,15 @@
 FROM node:alpine
 
 COPY src/dispatcher/package.json src/dispatcher/package-lock.json /home/
+
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/dispatcher/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+
+CMD ["./start-worker.sh"]

--- a/src/dispatcher/Dockerfile
+++ b/src/dispatcher/Dockerfile
@@ -2,10 +2,8 @@ FROM node:alpine
 
 COPY src/dispatcher/package.json src/dispatcher/package-lock.json /home/
 
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/download-file/Dockerfile
+++ b/src/download-file/Dockerfile
@@ -1,10 +1,8 @@
 FROM node:alpine
 
 COPY src/download-file/package.json src/download-file/package-lock.json /home/
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/download-file/Dockerfile
+++ b/src/download-file/Dockerfile
@@ -1,8 +1,13 @@
 FROM node:alpine
 
 COPY src/download-file/package.json src/download-file/package-lock.json /home/
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/download-file/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+CMD ["./start-worker.sh"]

--- a/src/geoserver-publish-geotiff/Dockerfile
+++ b/src/geoserver-publish-geotiff/Dockerfile
@@ -1,8 +1,13 @@
 FROM node:alpine
 
 COPY src/geoserver-publish-geotiff/package.json src/geoserver-publish-geotiff/package-lock.json /home/
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/geoserver-publish-geotiff/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+CMD ["./start-worker.sh"]

--- a/src/geoserver-publish-geotiff/Dockerfile
+++ b/src/geoserver-publish-geotiff/Dockerfile
@@ -1,10 +1,8 @@
 FROM node:alpine
 
 COPY src/geoserver-publish-geotiff/package.json src/geoserver-publish-geotiff/package-lock.json /home/
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/geoserver-publish-imagemosaic/Dockerfile
+++ b/src/geoserver-publish-imagemosaic/Dockerfile
@@ -2,10 +2,8 @@ FROM node:alpine
 
 COPY src/geoserver-publish-imagemosaic/package.json src/geoserver-publish-imagemosaic/package-lock.json /home/
 
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/geoserver-publish-imagemosaic/Dockerfile
+++ b/src/geoserver-publish-imagemosaic/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:alpine
 
 COPY src/geoserver-publish-imagemosaic/package.json src/geoserver-publish-imagemosaic/package-lock.json /home/
+
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/geoserver-publish-imagemosaic/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+CMD ["./start-worker.sh"]

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -4,8 +4,12 @@ RUN apt update \
     && apt install -y gdal-bin
 
 COPY src/geotiff-validator/package.json src/geotiff-validator/package-lock.json /home/
+COPY  /wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/geotiff-validator/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+CMD [ "./wait-for.sh", ${RABBITHOST}":15672", "--", "sh", "-c", "node worker/index.js"]
+

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -5,10 +5,8 @@ RUN apt update \
     && apt install -y gdal-bin netcat
 
 COPY src/geotiff-validator/package.json src/geotiff-validator/package-lock.json /home/
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /home/
 RUN npm install
 COPY src/geotiff-validator/index.js worker/
 COPY src/workerTemplate.js .
-CMD [ "./wait-for.sh", ${RABBITHOST}":15672", "--", "sh", "-c", "node worker/index.js"]
+CMD [ "./wait-for.sh", ${RABBITHOST}":5672", "--", "sh", "-c", "node worker/index.js"]
 

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -1,15 +1,18 @@
 FROM node:bullseye
 
+# netcat needed for 'wait-for' script
 RUN apt update \
-    && apt install -y gdal-bin
+    && apt install -y gdal-bin netcat
 
 COPY src/geotiff-validator/package.json src/geotiff-validator/package-lock.json /home/
-COPY  /wait-for.sh /home/wait-for.sh
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
 RUN chmod +x /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install
 COPY src/geotiff-validator/index.js worker/
 COPY src/workerTemplate.js .
-CMD [ "./wait-for.sh", ${RABBITHOST}":5672", "--", "sh", "-c", "node worker/index.js"]
 
+CMD ["./start-worker.sh"]

--- a/src/send-email/Dockerfile
+++ b/src/send-email/Dockerfile
@@ -12,10 +12,8 @@ ENV WORKERQUEUE send-email
 ENV RESULTSQUEUE results
 
 COPY src/send-email/package.json src/send-email/package-lock.json /home/
-COPY src/send-email/start-email-worker.sh /home/start-email-worker.sh
-RUN chmod +x /home/start-email-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+COPY src/send-email/start-email-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-email-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/send-email/Dockerfile
+++ b/src/send-email/Dockerfile
@@ -12,8 +12,14 @@ ENV WORKERQUEUE send-email
 ENV RESULTSQUEUE results
 
 COPY src/send-email/package.json src/send-email/package-lock.json /home/
+COPY src/send-email/start-email-worker.sh /home/start-email-worker.sh
+RUN chmod +x /home/start-email-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/send-email/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js ${MAILHOST} ${MAILPORT} ${SECURE} ${AUTHUSER} ${AUTHPASS} ${FROMSENDERNAME} ${FROMSENDEREMAIL}"]
+
+CMD ["./start-email-worker.sh"]

--- a/src/send-email/start-email-worker.sh
+++ b/src/send-email/start-email-worker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# command called externally to be able to use the variables
+./wait-for.sh "${RABBITHOST}:5672" -- node worker/index.js ${MAILHOST} ${MAILPORT} ${SECURE} ${AUTHUSER} ${AUTHPASS} ${FROMSENDERNAME} ${FROMSENDEREMAIL}"

--- a/src/send-mattermost-message/Dockerfile
+++ b/src/send-mattermost-message/Dockerfile
@@ -1,10 +1,9 @@
 FROM node:alpine
 
 COPY src/send-mattermost-message/package.json src/send-mattermost-message/package-lock.json /home/
-COPY util/start-worker.sh /home/start-worker.sh
-RUN chmod +x /home/start-worker.sh
-COPY util/wait-for.sh /home/wait-for.sh
-RUN chmod +x /home/wait-for.sh
+
+COPY util/start-worker.sh util/wait-for.sh /home/
+RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 
 WORKDIR /home/
 RUN npm install

--- a/src/send-mattermost-message/Dockerfile
+++ b/src/send-mattermost-message/Dockerfile
@@ -1,8 +1,13 @@
 FROM node:alpine
 
 COPY src/send-mattermost-message/package.json src/send-mattermost-message/package-lock.json /home/
+COPY util/start-worker.sh /home/start-worker.sh
+RUN chmod +x /home/start-worker.sh
+COPY util/wait-for.sh /home/wait-for.sh
+RUN chmod +x /home/wait-for.sh
+
 WORKDIR /home/
 RUN npm install
 COPY src/send-mattermost-message/index.js worker/
 COPY src/workerTemplate.js .
-CMD ["sh", "-c", "node worker/index.js"]
+CMD ["./start-worker.sh"]

--- a/util/start-worker.sh
+++ b/util/start-worker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# command called externally to be able to use the variable 'RABBITHOST'
+./wait-for.sh "${RABBITHOST}:5672" -- node worker/index.js

--- a/util/wait-for.sh
+++ b/util/wait-for.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 Eficode Oy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -- "$@" -- "$TIMEOUT" "$QUIET" "$HOST" "$PORT" "$result"
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+ if ! command -v nc >/dev/null; then
+    echoerr 'nc command is missing!'
+    exit 1
+  fi
+
+  while :; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 6 ] ; then
+        for result in $(seq $(($# - 6))); do
+          result=$1
+          shift
+          set -- "$@" "$result"
+        done
+
+        TIMEOUT=$2 QUIET=$3 HOST=$4 PORT=$5 result=$6
+        shift 6
+        exec "$@"
+      fi
+      exit 0
+    fi
+
+    if [ "$TIMEOUT" -le 0 ]; then
+      break
+    fi
+    TIMEOUT=$((TIMEOUT - 1))
+
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while :; do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -q-*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
+    -q*)
+    QUIET=1
+    result=$1
+    shift 1
+    set -- -"${result#-q}" "$@"
+    ;;
+    -t | --timeout)
+    TIMEOUT="$2"
+    shift 2
+    ;;
+    -t*)
+    TIMEOUT="${1#-t}"
+    shift 1
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    -*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
+    *)
+    QUIET=0
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if ! [ "$TIMEOUT" -ge 0 ] 2>/dev/null; then
+  echoerr "Error: invalid timeout '$TIMEOUT'"
+  usage 3
+fi
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
- references https://github.com/klips-project/rabbitmq-worker/issues/78
- ensures workers are started after RabbitMQ is available
