### PR TITLE
geoserver-publish-imagemosaic: Move file to coverage store

### DIFF
--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -54,7 +54,9 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
     // move coverage to coverage store folder to keep file structure clean in data directory
     const fileName = path.basename(coverageToAdd);
     const oldPath = coverageToAdd;
+    // the internal geoserver url always starts with 'file:', so we split it and take the second index
     const coverageStorePath = covStoreObject.coverageStore.url.split(":")[1];
+    // TODO read the geoserver data dir path from rest api
     const newPath = `/opt/geoserver_data/${coverageStorePath}/${fileName}`;
 
     // Test if path can be accessed, probably not needed

--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -38,6 +38,7 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
   const workspace = inputs[0];
   const covStore = inputs[1];
   const coverageToAdd = inputs[2];
+  let newPath;
 
   const geoServerAvailable = await isGeoServerAvailable();
 
@@ -64,10 +65,9 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
     // the internal geoserver url always starts with 'file:', so we split it and use the second index
     const coverageStorePath = covStoreObject.coverageStore.url.split(":")[1];
     // TODO read the geoserver data dir path from rest api
-    const newPath = `/opt/geoserver_data/${coverageStorePath}/${fileName}`;
+    newPath = `/opt/geoserver_data/${coverageStorePath}/${fileName}`;
 
-    // Test if path can be accessed, probably not needed
-    await fsPromises.access(coverageToAdd);
+    // Move geotiff
     await fsPromises.rename(oldPath, newPath);
     
     await grc.imagemosaics.addGranuleByServerFile(
@@ -80,8 +80,7 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
   }
 
   workerJob.status = 'success';
-  // TODO maybe output the new filepath
-  workerJob.outputs = [];
+  workerJob.outputs = [newPath];
 };
 
 /**

--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -1,7 +1,7 @@
 import { GeoServerRestClient } from 'geoserver-node-client';
 import { log, initialize } from '../workerTemplate.js';
-import path from "path";
 import fsPromises from 'fs/promises';
+import path from 'path';
 
 const url = process.env.GEOSERVER_REST_URL;
 const user = process.env.GEOSERVER_USER;
@@ -73,7 +73,8 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
   }
 
   workerJob.status = 'success';
-  workerJob.outputs = [newPath];
+  // TODO maybe output the new filepath
+  workerJob.outputs = [];
 };
 
 // Initialize and start the worker process

--- a/src/geoserver-publish-imagemosaic/package-lock.json
+++ b/src/geoserver-publish-imagemosaic/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "amqplib": "^0.8.0",
-        "geoserver-node-client": "1.1.0"
+        "fs.promises": "^0.1.2",
+        "geoserver-node-client": "1.1.0",
+        "path": "^0.12.7"
       },
       "devDependencies": {
         "eslint": "^7.29.0"
@@ -763,6 +765,14 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/fs.promises": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
+      "integrity": "sha512-LNfkXdN6EToumV455EbdJaNxqLmEFqKqNZVIEyI2whtdpIppTsne2fHWgx05s+B2Aif29Lhzdz0AaOXKLvMGsA==",
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1078,6 +1088,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1103,6 +1122,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/progress": {
@@ -1417,6 +1444,19 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -2062,6 +2102,11 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "fs.promises": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
+      "integrity": "sha512-LNfkXdN6EToumV455EbdJaNxqLmEFqKqNZVIEyI2whtdpIppTsne2fHWgx05s+B2Aif29Lhzdz0AaOXKLvMGsA=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2309,6 +2354,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2326,6 +2380,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "progress": {
       "version": "2.0.3",
@@ -2553,6 +2612,21 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+        }
       }
     },
     "v8-compile-cache": {

--- a/src/geoserver-publish-imagemosaic/package.json
+++ b/src/geoserver-publish-imagemosaic/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "amqplib": "^0.8.0",
-    "geoserver-node-client": "1.1.0"
+    "fs.promises": "^0.1.2",
+    "geoserver-node-client": "1.1.0",
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "eslint": "^7.29.0"

--- a/src/geoserver-publish-imagemosaic/package.json
+++ b/src/geoserver-publish-imagemosaic/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "amqplib": "^0.8.0",
     "fs.promises": "^0.1.2",
-    "geoserver-node-client": "1.1.0",
-    "path": "^0.12.7"
+    "geoserver-node-client": "1.1.0"
   },
   "devDependencies": {
     "eslint": "^7.29.0"


### PR DESCRIPTION
This adds a function to move the input file to the directory of the coverage store using `fs.promises`.  
This is needed to keep the `geoserver_data` directory clean and deal with the single granule files afterwards (e.g. rollback worker).  

@JakobMiksch please check.