### PR TITLE
Remove redundant '.tif' suffix

### DIFF
--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -64,8 +64,7 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
     }
 
     const fileName = path.basename(coverageToAdd);
-
-    newPath =  path.join(geoserverDataDir, 'data', ws, covStore, `${fileName}.tif`);
+    newPath =  path.join(geoserverDataDir, 'data', ws, covStore, fileName);
 
     // Move GeoTiff
     await fsPromises.rename(coverageToAdd, newPath);


### PR DESCRIPTION
ensures files are with correct suffix, here with some samples before and after

```
0_20220902T1416.tif.tif        
0_20220902T1433.tif.tif        
0_20220902T1719.tif.tif        
0_20220903T2106.tif.tif        
0_20220915T1053.tif            
0_20220915T1053.tif.tif        
0_20220915T1106.tif            
datastore.properties           
dresden_temperature.properties 
indexer.properties             
sample_image.dat               
timeregex.properties           

```