### PR TITLE
Display formatted job JSON in logs

### DIFF
--- a/src/dispatcher/index.js
+++ b/src/dispatcher/index.js
@@ -138,7 +138,7 @@ const handleNextTask = (msg) => {
     } else {
       // overall job success
       job.status = 'success';
-      log('Job finished successfully: ' + JSON.stringify(job));
+      log('Job finished successfully: \n' + JSON.stringify(job, null, 2));
     }
     channel.ack(msg);
   } catch (e) {


### PR DESCRIPTION
displays the whole job JSON in logs, useful for debugging.

@hwbllmnn @hblitza do you think we should enable when there is dev mode enabled?

![image](https://user-images.githubusercontent.com/15704517/188672345-5c475c80-0187-47cc-97bb-eb736ac25b1b.png)
