### PR TITLE
Download test data to tmp directory

### DIFF
--- a/src/download-file/index.spec.js
+++ b/src/download-file/index.spec.js
@@ -9,8 +9,9 @@ test('test if download-file can be called', async () => {
     const job = {};
     await download(job, [
         'https://raw.githubusercontent.com/klips-project/rabbitmq-worker/main/README.md',
-        'test'
+        '/tmp/test'
     ]);
+    console.log(job);
     expect(job.outputs).toBeDefined();
     expect(job.outputs.length).toBe(1);
 });

--- a/src/download-file/index.spec.js
+++ b/src/download-file/index.spec.js
@@ -11,7 +11,6 @@ test('test if download-file can be called', async () => {
         'https://raw.githubusercontent.com/klips-project/rabbitmq-worker/main/README.md',
         '/tmp/test'
     ]);
-    console.log(job);
     expect(job.outputs).toBeDefined();
     expect(job.outputs.length).toBe(1);
 });

--- a/src/geotiff-validator/index.spec.js
+++ b/src/geotiff-validator/index.spec.js
@@ -8,12 +8,13 @@ test('test if geotiff-validate can be loaded', () => {
 
 test('test if geotiff-validate can be called', async () => {
     let job = {};
+    const downloadPath = '/tmp/test';
     await download(job, [
         'https://raw.githubusercontent.com/klips-project/klips-sdi/main/mocked-webspace/sample_germany_small.tif',
-        'test'
+        downloadPath
     ]);
     job = {};
-    await validate(job, ['test']);
+    await validate(job, [downloadPath]);
     expect(job.outputs).toBeDefined();
     expect(job.outputs.length).toBe(1);
 });


### PR DESCRIPTION
Download test data to tmp directory to prevent an remaining file `test` in the repo.