### PR TITLE
ImageMosaic Worker refactor prototype granule and time dimension

### DIFF
--- a/src/geoserver-create-imagemosaic-datastore/Dockerfile
+++ b/src/geoserver-create-imagemosaic-datastore/Dockerfile
@@ -10,7 +10,6 @@ RUN chmod +x /home/start-worker.sh /home/wait-for.sh
 WORKDIR /home/
 RUN npm install
 COPY src/geoserver-create-imagemosaic-datastore/index.js worker/
-COPY src/geoserver-create-imagemosaic-datastore/dummy.tif worker/
 COPY src/workerTemplate.js .
 COPY src/geoserver-create-imagemosaic-datastore/gs-img-mosaic-tpl ./gs-img-mosaic-tpl
 CMD ["./start-worker.sh"]

--- a/src/geoserver-create-imagemosaic-datastore/index.js
+++ b/src/geoserver-create-imagemosaic-datastore/index.js
@@ -31,7 +31,7 @@ const grc = new GeoServerRestClient(url, user, pw);
  * @param {Array} inputs The inputs for this process
  *   First input is the workspace to publish to
  *   Second input is the name of the coverage store to be created
- *   Third input is the path to prototype dataset for the coverage to be supported
+ *   Third input is the path to the first coverage that also serves as prototype for the store
  * @example
     {
        "id": 123,

--- a/src/geoserver-create-imagemosaic-datastore/index.js
+++ b/src/geoserver-create-imagemosaic-datastore/index.js
@@ -137,7 +137,7 @@ const geoserverCreateImageMosaicDatastore = async (workerJob, inputs) => {
     // http://localhost:8080/geoserver/rest/workspaces/{ws}/coveragestores/{covname}/coverages.json?list=all
 
     log(`Enabling time for layer "${ws}:${covStore}"`);
-    await grc.layers.enableTimeCoverage(ws, covStore, covStore, 'LIST', 3600000, 'MAXIMUM', true, false, 'PT30M');
+    await grc.layers.enableTimeCoverage(ws, covStore, covStore, 'LIST', 3600000, 'MAXIMUM', true, false, 'PT1H');
     log(`Time dimension  for layer "${ws}:${covStore}" successfully enabled.`);
 
   } catch (error) {

--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -40,7 +40,6 @@ const grc = new GeoServerRestClient(url, user, pw);
 const geoserverPublishImageMosaic = async (workerJob, inputs) => {
   const ws = inputs[0];
   const covStore = inputs[1];
-  const layerName = inputs[1];
   const coverageToAdd = inputs[2];
   const replaceExistingGranule = inputs[3] ? inputs[3] : false;
 
@@ -83,23 +82,6 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
       ws, covStore, newPath
     );
     log('Successfully added new granule to coverage store.');
-
-    // check if layer has time dimension enabled
-    let hasTime = false;
-    const coverage = await grc.layers.getCoverage(ws, covStore, covStore);
-    if (coverage && coverage.coverage.metadata && coverage.coverage.metadata.entry &&
-      coverage.coverage.metadata.entry['@key'] === 'time' && (typeof coverage.coverage.metadata.entry.dimensionInfo === 'object')) {
-      const dimInfo = coverage.coverage.metadata.entry.dimensionInfo;
-      if (dimInfo.enabled === true && dimInfo.acceptableInterval) {
-        hasTime = true;
-      }
-    }
-
-    if (!hasTime) {
-      log(`Enabling time for layer "${ws}:${layerName}"`);
-      await grc.layers.enableTimeCoverage(ws, covStore, covStore, 'LIST', 3600000, 'MAXIMUM', true, false, 'PT30M');
-      log(`Time dimension  for layer "${ws}:${covStore}" successfully enabled.`);
-    }
 
   } catch (error) {
     log(error);


### PR DESCRIPTION
Some adaptions for the `imagemosaic` related workers:
- require a prototype granule for a new imagemosaic datastore (following: https://docs.geoserver.org/2.21.x/en/user/community/cog/mosaic.html)
- enable time dimension in the `create-imagemosaic-datatstore` makes more sense, as a layer is already created at this place
- initializing the datastore does not seem to be necessary to me, please doublecheck.

samplejob for testing:  
```
{
    "job": [
      {
        "id": 187,
        "type": "geoserver-create-imagemosaic-datastore",
        "inputs": [
            "dresden",
            "ecostress",
            "/opt/geoserver_data/20220902T0420.tif"
          ]
      }
    ]
}
```

@JakobMiksch @hwbllmnn  please check.