### PR TITLE
Add worker property to log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ tail -f worker.log | pino-pretty -c -i job
 
 # print single lines
 tail -f worker.log | pino-pretty -c -S
+
+# filter by an attribute using 'jq'
+cat logs/worker.log | jq -c 'select(.worker == "download-file")' | pino-pretty -c
 ```
 
 ## logrotate

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ tail -f worker.log | pino-pretty -c -i job
 tail -f worker.log | pino-pretty -c -S
 
 # filter by an attribute using 'jq'
-cat logs/worker.log | jq -c 'select(.worker == "download-file")' | pino-pretty -c
+cat logs/worker.log | jq -c 'select(.type == "download-file")' | pino-pretty -c
 ```
 
 ## logrotate

--- a/src/create-file/Dockerfile
+++ b/src/create-file/Dockerfile
@@ -8,5 +8,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/create-file/index.js worker/
 COPY src/workerTemplate.js .
-COPY src/logger.js . 
+COPY src/create-file/child-logger.js worker/
+COPY src/logger.js .
 CMD ["./start-worker.sh"]

--- a/src/create-file/child-logger.js
+++ b/src/create-file/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'create-file' });

--- a/src/create-file/child-logger.js
+++ b/src/create-file/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'create-file' });
+export default logger.child({ type: 'create-file' });

--- a/src/create-file/index.js
+++ b/src/create-file/index.js
@@ -1,7 +1,7 @@
 import fsPromises from 'fs/promises';
 import path from 'path';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;

--- a/src/dispatcher/Dockerfile
+++ b/src/dispatcher/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /home/
 RUN npm install
 COPY src/dispatcher/index.js worker/
 COPY src/dispatcher/dispatcher.js worker/
+COPY src/dispatcher/child-logger.js worker/
 COPY src/logger.js .
 COPY src/workerTemplate.js .
 

--- a/src/dispatcher/child-logger.js
+++ b/src/dispatcher/child-logger.js
@@ -1,0 +1,3 @@
+import {logger} from '../logger.js';
+
+export default logger.child({ worker: 'dispatcher' });

--- a/src/dispatcher/child-logger.js
+++ b/src/dispatcher/child-logger.js
@@ -1,3 +1,3 @@
 import {logger} from '../logger.js';
 
-export default logger.child({ worker: 'dispatcher' });
+export default logger.child({ type: 'dispatcher' });

--- a/src/dispatcher/dispatcher.js
+++ b/src/dispatcher/dispatcher.js
@@ -1,6 +1,6 @@
 import amqp from 'amqplib';
 import { randomUUID } from 'crypto';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 /**
  * Dispatcher that handles communication between all workers via RabbitMQ.

--- a/src/dispatcher/index.js
+++ b/src/dispatcher/index.js
@@ -1,5 +1,5 @@
 import { Dispatcher } from './dispatcher.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;

--- a/src/download-file/Dockerfile
+++ b/src/download-file/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /home/
 RUN npm install
 COPY src/download-file/index.js worker/
 COPY src/download-file/downloader.js worker/
+COPY src/download-file/child-logger.js worker/
 COPY src/logger.js .
 COPY src/workerTemplate.js .
 CMD ["./start-worker.sh"]

--- a/src/download-file/child-logger.js
+++ b/src/download-file/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'download-file' });
+export default logger.child({ type: 'download-file' });

--- a/src/download-file/child-logger.js
+++ b/src/download-file/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'download-file' });

--- a/src/download-file/downloader.js
+++ b/src/download-file/downloader.js
@@ -1,7 +1,7 @@
 import http from 'http';
 import https from 'https';
 import fs from 'fs';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 /**
  * Downloads a file from the internet to the local filesystem.

--- a/src/download-file/index.js
+++ b/src/download-file/index.js
@@ -11,8 +11,6 @@ const rabbitHost = process.env.RABBITHOST;
 const rabbitUser = process.env.RABBITUSER;
 const rabbitPass = process.env.RABBITPASS;
 
-logger.debug('HELLO DOWNLOAD');
-
 /**
  * Downloads data into the given target from the given URL.
  * Modifies the given job object in place with status and results.

--- a/src/download-file/index.js
+++ b/src/download-file/index.js
@@ -3,13 +3,15 @@ import path from 'path';
 import { URL } from 'url';
 import downloadFile from './downloader.js';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;
 const rabbitHost = process.env.RABBITHOST;
 const rabbitUser = process.env.RABBITUSER;
 const rabbitPass = process.env.RABBITPASS;
+
+logger.debug('HELLO DOWNLOAD');
 
 /**
  * Downloads data into the given target from the given URL.

--- a/src/geonetwork-publish-metadata/Dockerfile
+++ b/src/geonetwork-publish-metadata/Dockerfile
@@ -11,6 +11,8 @@ COPY src/geonetwork-publish-metadata/package.json src/geonetwork-publish-metadat
 WORKDIR /home/
 RUN npm install
 COPY src/geonetwork-publish-metadata/index.js worker/
+COPY src/geonetwork-publish-metadata/child-logger.js worker/
 COPY src/workerTemplate.js .
 COPY src/gnos-client.js .
+
 CMD ["sh", "-c", "node worker/index.js ${GNHOST} ${GNUSER} ${GNPASS}"]

--- a/src/geonetwork-publish-metadata/child-logger.js
+++ b/src/geonetwork-publish-metadata/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geonetwork-publish-metadata' });

--- a/src/geonetwork-publish-metadata/child-logger.js
+++ b/src/geonetwork-publish-metadata/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geonetwork-publish-metadata' });
+export default logger.child({ type: 'geonetwork-publish-metadata' });

--- a/src/geonetwork-publish-metadata/index.js
+++ b/src/geonetwork-publish-metadata/index.js
@@ -1,5 +1,5 @@
 import GeoNetworkClient from '../gnos-client.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 import { initialize } from '../workerTemplate.js';
 
 const url = process.env.GNHOST;

--- a/src/geoserver-create-imagemosaic-datastore/Dockerfile
+++ b/src/geoserver-create-imagemosaic-datastore/Dockerfile
@@ -14,6 +14,7 @@ COPY src/geoserver-create-imagemosaic-datastore/util.js worker/
 COPY src/geoserver-create-imagemosaic-datastore/create-mosaic-store.js worker/
 COPY src/geoserver-create-imagemosaic-datastore/geoserver-config-templates.js worker/
 COPY src/workerTemplate.js .
+COPY src/geoserver-create-imagemosaic-datastore/child-logger.js worker/
 COPY src/logger.js .
 
 CMD ["./start-worker.sh"]

--- a/src/geoserver-create-imagemosaic-datastore/child-logger.js
+++ b/src/geoserver-create-imagemosaic-datastore/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geoserver-create-imagemosaic-datastore' });

--- a/src/geoserver-create-imagemosaic-datastore/child-logger.js
+++ b/src/geoserver-create-imagemosaic-datastore/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geoserver-create-imagemosaic-datastore' });
+export default logger.child({ type: 'geoserver-create-imagemosaic-datastore' });

--- a/src/geoserver-create-imagemosaic-datastore/create-mosaic-store.js
+++ b/src/geoserver-create-imagemosaic-datastore/create-mosaic-store.js
@@ -2,7 +2,7 @@ import fsPromises from 'fs/promises';
 import path from 'path';
 import { classicConfigFiles, cogConfigFiles } from './geoserver-config-templates.js';
 import AdmZip from 'adm-zip';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 /**
  * Create a COG-based image mosaic store with time support.

--- a/src/geoserver-create-imagemosaic-datastore/index.js
+++ b/src/geoserver-create-imagemosaic-datastore/index.js
@@ -1,7 +1,7 @@
 import { GeoServerRestClient } from 'geoserver-node-client';
 import { initialize } from '../workerTemplate.js';
 import { createClassicMosaicStore, createCogMosaicStore } from './create-mosaic-store.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const url = process.env.GEOSERVER_REST_URL;

--- a/src/geoserver-publish-geotiff/Dockerfile
+++ b/src/geoserver-publish-geotiff/Dockerfile
@@ -8,5 +8,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/geoserver-publish-geotiff/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/geoserver-publish-geotiff/child-logger.js worker/
 COPY src/logger.js .
 CMD ["./start-worker.sh"]

--- a/src/geoserver-publish-geotiff/child-logger.js
+++ b/src/geoserver-publish-geotiff/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geoserver-publish-geotiff' });
+export default logger.child({ type: 'geoserver-publish-geotiff' });

--- a/src/geoserver-publish-geotiff/child-logger.js
+++ b/src/geoserver-publish-geotiff/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geoserver-publish-geotiff' });

--- a/src/geoserver-publish-geotiff/index.js
+++ b/src/geoserver-publish-geotiff/index.js
@@ -1,6 +1,6 @@
 import { GeoServerRestClient } from 'geoserver-node-client';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const url = process.env.GEOSERVER_REST_URL;
 const user = process.env.GEOSERVER_USER;

--- a/src/geoserver-publish-imagemosaic/Dockerfile
+++ b/src/geoserver-publish-imagemosaic/Dockerfile
@@ -10,5 +10,6 @@ RUN npm install
 COPY src/geoserver-publish-imagemosaic/index.js worker/
 COPY src/geoserver-publish-imagemosaic/publish-granule.js worker/
 COPY src/workerTemplate.js .
+COPY src/geoserver-publish-imagemosaic/child-logger.js worker/
 COPY src/logger.js .
 CMD ["./start-worker.sh"]

--- a/src/geoserver-publish-imagemosaic/child-logger.js
+++ b/src/geoserver-publish-imagemosaic/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geoserver-publish-imagemosaic' });
+export default logger.child({ type: 'geoserver-publish-imagemosaic' });

--- a/src/geoserver-publish-imagemosaic/child-logger.js
+++ b/src/geoserver-publish-imagemosaic/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geoserver-publish-imagemosaic' });

--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -47,6 +47,8 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
 
   const geoServerAvailable = await grc.about.exists();
 
+  logger.debug('Publishing GeoTIFF to image mosaic store...');
+
   if (!geoServerAvailable) {
     logger.debug('Geoserver not available');
     workerJob.missingPreconditions = true;
@@ -70,6 +72,8 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
     logger.error(error);
     throw 'Could not add new granule to coverage store.';
   }
+
+  logger.debug('Publishing GeoTIFF finished.');
 
   workerJob.status = 'success';
   workerJob.outputs = [newPath];

--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -1,7 +1,7 @@
 import { GeoServerRestClient } from 'geoserver-node-client';
 import { initialize } from '../workerTemplate.js';
 import { publishClassicGranule, publishCogGranule } from './publish-granule.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const url = process.env.GEOSERVER_REST_URL;
 const user = process.env.GEOSERVER_USER;

--- a/src/geoserver-publish-layer-from-db/Dockerfile
+++ b/src/geoserver-publish-layer-from-db/Dockerfile
@@ -12,5 +12,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/geoserver-publish-layer-from-db/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/geoserver-publish-layer-from-db/child-logger.js worker/
 COPY src/logger.js .
 CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS}"]

--- a/src/geoserver-publish-layer-from-db/child-logger.js
+++ b/src/geoserver-publish-layer-from-db/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geoserver-publish-layer-from-db' });

--- a/src/geoserver-publish-layer-from-db/child-logger.js
+++ b/src/geoserver-publish-layer-from-db/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geoserver-publish-layer-from-db' });
+export default logger.child({ type: 'geoserver-publish-layer-from-db' });

--- a/src/geoserver-publish-layer-from-db/index.js
+++ b/src/geoserver-publish-layer-from-db/index.js
@@ -1,6 +1,6 @@
 import GeoServerRestClient from 'geoserver-node-client/geoserver-rest-client.js';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';;
 
 
 const url = process.env.GSHOST;

--- a/src/geoserver-publish-layer-from-db/index.js
+++ b/src/geoserver-publish-layer-from-db/index.js
@@ -1,6 +1,6 @@
 import GeoServerRestClient from 'geoserver-node-client/geoserver-rest-client.js';
 import { initialize } from '../workerTemplate.js';
-import logger from './child-logger.js';;
+import logger from './child-logger.js';
 
 
 const url = process.env.GSHOST;

--- a/src/geoserver-publish-sld/Dockerfile
+++ b/src/geoserver-publish-sld/Dockerfile
@@ -12,5 +12,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/geoserver-publish-sld/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/geoserver-publish-sld/child-logger.js worker/
 COPY src/logger.js .
 CMD ["sh", "-c", "node worker/index.js ${GSHOST} ${GSUSER} ${GSPASS}"]

--- a/src/geoserver-publish-sld/child-logger.js
+++ b/src/geoserver-publish-sld/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geoserver-publish-sld' });
+export default logger.child({ type: 'geoserver-publish-sld' });

--- a/src/geoserver-publish-sld/child-logger.js
+++ b/src/geoserver-publish-sld/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geoserver-publish-sld' });

--- a/src/geoserver-publish-sld/index.js
+++ b/src/geoserver-publish-sld/index.js
@@ -1,6 +1,6 @@
 import GeoServerRestClient from 'geoserver-node-client/geoserver-rest-client.js';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const url = process.env.GSHOST;

--- a/src/geotiff-optimizer/Dockerfile
+++ b/src/geotiff-optimizer/Dockerfile
@@ -11,5 +11,6 @@ RUN npm install
 COPY src/geotiff-optimizer/index.js worker/
 COPY src/geotiff-optimizer/optimize-geotiff.js worker/
 COPY src/workerTemplate.js .
+COPY src/geotiff-optimizer/child-logger.js worker/
 COPY src/logger.js .
 CMD ["./start-worker.sh"]

--- a/src/geotiff-optimizer/child-logger.js
+++ b/src/geotiff-optimizer/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geotiff-optimizer' });
+export default logger.child({ type: 'geotiff-optimizer' });

--- a/src/geotiff-optimizer/child-logger.js
+++ b/src/geotiff-optimizer/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geotiff-optimizer' });

--- a/src/geotiff-optimizer/index.js
+++ b/src/geotiff-optimizer/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { initialize } from '../workerTemplate.js';
 import optimizeGeoTiff from './optimize-geotiff.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -21,6 +21,7 @@ COPY src/geotiff-validator/index.js worker/
 COPY src/geotiff-validator/validator.js worker/
 COPY src/geotiff-validator/worker.js worker/
 COPY src/workerTemplate.js .
+COPY src/geotiff-validator/child-logger.js worker/
 COPY src/logger.js .
 ADD src/geotiff-validator/config config
 

--- a/src/geotiff-validator/child-logger.js
+++ b/src/geotiff-validator/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'geotiff-validator' });
+export default logger.child({ type: 'geotiff-validator' });

--- a/src/geotiff-validator/child-logger.js
+++ b/src/geotiff-validator/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'geotiff-validator' });

--- a/src/geotiff-validator/index.js
+++ b/src/geotiff-validator/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { initialize } from '../workerTemplate.js';
 import { createGeotiffValidationFun } from './worker.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;

--- a/src/gunzip-file/Dockerfile
+++ b/src/gunzip-file/Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/gunzip-file/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/gunzip-file/child-logger.js worker/
 COPY src/logger.js .
 CMD ["sh", "-c", "node worker/index.js"]

--- a/src/gunzip-file/child-logger.js
+++ b/src/gunzip-file/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'gunzip-file' });
+export default logger.child({ type: 'gunzip-file' });

--- a/src/gunzip-file/child-logger.js
+++ b/src/gunzip-file/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'gunzip-file' });

--- a/src/gunzip-file/index.js
+++ b/src/gunzip-file/index.js
@@ -1,7 +1,7 @@
 import zlib from 'zlib';
 import fs from 'fs';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;

--- a/src/send-email/Dockerfile
+++ b/src/send-email/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /home/
 RUN npm install
 COPY src/send-email/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/send-email/child-logger.js worker/
 COPY src/logger.js .
 
 CMD ["./start-email-worker.sh"]

--- a/src/send-email/child-logger.js
+++ b/src/send-email/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'send-email' });

--- a/src/send-email/child-logger.js
+++ b/src/send-email/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'send-email' });
+export default logger.child({ type: 'send-email' });

--- a/src/send-email/index.js
+++ b/src/send-email/index.js
@@ -1,6 +1,6 @@
 import nodemailer from 'nodemailer';
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;

--- a/src/send-mattermost-message/Dockerfile
+++ b/src/send-mattermost-message/Dockerfile
@@ -10,5 +10,6 @@ RUN npm install
 COPY src/send-mattermost-message/index.js worker/
 COPY src/workerTemplate.js .
 
+COPY src/send-mattermost-message/child-logger.js worker/
 COPY src/logger.js .
 CMD ["./start-worker.sh"]

--- a/src/send-mattermost-message/child-logger.js
+++ b/src/send-mattermost-message/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'send-mattermost-message' });

--- a/src/send-mattermost-message/child-logger.js
+++ b/src/send-mattermost-message/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'send-mattermost-message' });
+export default logger.child({ type: 'send-mattermost-message' });

--- a/src/send-mattermost-message/index.js
+++ b/src/send-mattermost-message/index.js
@@ -1,6 +1,6 @@
 import { initialize } from '../workerTemplate.js';
 import fetch from 'node-fetch';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;

--- a/src/upload-file/Dockerfile
+++ b/src/upload-file/Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/upload-file/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/upload-file/child-logger.js worker/
 COPY src/logger.js .
 CMD ["sh", "-c", "node worker/index.js"]

--- a/src/upload-file/child-logger.js
+++ b/src/upload-file/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'upload-file' });

--- a/src/upload-file/child-logger.js
+++ b/src/upload-file/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'upload-file' });
+export default logger.child({ type: 'upload-file' });

--- a/src/upload-file/index.js
+++ b/src/upload-file/index.js
@@ -3,7 +3,7 @@ import FormData from 'form-data';
 import fetch from 'node-fetch';
 
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 const workerQueue = process.env.WORKERQUEUE;
 const resultQueue = process.env.RESULTSQUEUE;

--- a/src/workerTemplate.js
+++ b/src/workerTemplate.js
@@ -52,7 +52,7 @@ export async function initialize(
     durable: true
   });
 
-  logger.debug(`Worker waiting for messages in ${workerQueue}.`);
+  logger.debug({type: workerQueue}, `Worker waiting for messages ... `);
   await connectToQueue(
     workerQueue,
     resultQueue,

--- a/src/zip-handler/Dockerfile
+++ b/src/zip-handler/Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /home/
 RUN npm install
 COPY src/zip-handler/index.js worker/
 COPY src/workerTemplate.js .
+COPY src/zip-handler/child-logger.js worker/
 COPY src/logger.js .
 CMD ["sh", "-c", "node worker/index.js"]

--- a/src/zip-handler/child-logger.js
+++ b/src/zip-handler/child-logger.js
@@ -1,3 +1,3 @@
 import { logger } from '../logger.js';
 
-export default logger.child({ worker: 'zip-handler' });
+export default logger.child({ type: 'zip-handler' });

--- a/src/zip-handler/child-logger.js
+++ b/src/zip-handler/child-logger.js
@@ -1,0 +1,3 @@
+import { logger } from '../logger.js';
+
+export default logger.child({ worker: 'zip-handler' });

--- a/src/zip-handler/index.js
+++ b/src/zip-handler/index.js
@@ -5,7 +5,7 @@ import unzip from 'unzipper';
 import path from 'path';
 
 import { initialize } from '../workerTemplate.js';
-import { logger } from '../logger.js';
+import logger from './child-logger.js';
 
 
 const workerQueue = process.env.WORKERQUEUE;


### PR DESCRIPTION
- add a property `worker` that specifies the worker type
- needed to properly filter logs 

![image](https://user-images.githubusercontent.com/15704517/215157397-0fe55b71-7713-4d26-aeab-ba72c1d90d96.png)
