### PR TITLE
geotiff-optimizer: set compression to DEFLATE

### DIFF
--- a/src/geotiff-optimizer/optimize-geotiff.js
+++ b/src/geotiff-optimizer/optimize-geotiff.js
@@ -29,12 +29,14 @@ const execShellCommand = (cmd) => {
  *
  * @param {String} inputPath The path of the GeoTIFF to convert
  * @param {String} outputPath The path where the created COG shall be stored
+ * @param {String} [compression=DEFLATE] The compression to use. For possible options see:
+ *                                       https://gdal.org/drivers/raster/cog.html#creation-options
  *
  * @returns {Promise<String>} A Promise that resolves to the console output of the underlying GDAL process
  *
  * @throws If provided paths are invalid or conversion fails, an error is thrown
  */
-const optimizeGeoTiff = async (inputPath, outputPath) => {
+const optimizeGeoTiff = async (inputPath, outputPath, compression = "DEFLATE") => {
     // valdate inputPath
     if (! await fs.existsSync(inputPath)){
         throw `Input file does not exist: ${inputPath}`;
@@ -46,7 +48,7 @@ const optimizeGeoTiff = async (inputPath, outputPath) => {
         throw `Output directory does not exist: ${outputDir}`;
     }
 
-    const makeCogCmd = `gdal_translate ${inputPath} ${outputPath} -of COG -co COMPRESS=LZW`;
+    const makeCogCmd = `gdal_translate ${inputPath} ${outputPath} -of COG -co COMPRESS=${compression}`;
 
     return await execShellCommand(makeCogCmd);
 }

--- a/src/geotiff-optimizer/optimize-geotiff.spec.js
+++ b/src/geotiff-optimizer/optimize-geotiff.spec.js
@@ -1,6 +1,7 @@
 import optimizeGeoTiff from './optimize-geotiff.js';
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
 
 const baseDir = 'src/geotiff-optimizer/sample_data/'
 const originalFilePath = path.join(baseDir, 'sample.tif');
@@ -9,7 +10,7 @@ const inputPath = path.join(workingDir, 'sample.tif');
 const outputPath = path.join(workingDir, 'sample-cog.tif');
 
 beforeAll(() => {
-    fs.mkdirSync(workingDir, {recursive: true})
+    fs.mkdirSync(workingDir, { recursive: true })
     fs.copyFileSync(originalFilePath, inputPath);
 });
 
@@ -26,4 +27,23 @@ test('Check if COG is being created', async () => {
     await optimizeGeoTiff(inputPath, outputPath);
     const outputExists = fs.existsSync(outputPath);
     expect(outputExists).toBe(true);
+});
+
+test('Compression Type is set to DEFLATE by default', async () => {
+    await optimizeGeoTiff(inputPath, outputPath);
+
+    const cliOutput = execSync(`gdalinfo -json ${outputPath}`);
+    const cogInfo = JSON.parse(cliOutput.toString());
+    const outCompression = cogInfo['metadata']['IMAGE_STRUCTURE']['COMPRESSION'];
+    expect(outCompression).toBe('DEFLATE');
+});
+
+test('Compression Type can be set to LZW', async () => {
+    const lzwCompression = 'LZW';
+    await optimizeGeoTiff(inputPath, outputPath, lzwCompression);
+
+    const cliOutput = execSync(`gdalinfo -json ${outputPath}`);
+    const cogInfo = JSON.parse(cliOutput.toString());
+    const outCompression = cogInfo['metadata']['IMAGE_STRUCTURE']['COMPRESSION'];
+    expect(outCompression).toBe(lzwCompression);
 });


### PR DESCRIPTION
- DEFLATE compression is set to default
- reduces the output file size by 50%
- other compressions could be set as argument of the function