### PR TITLE
geotiff-validator: refactor

### DIFF
--- a/src/geotiff-validator/validator.js
+++ b/src/geotiff-validator/validator.js
@@ -11,9 +11,9 @@ import logger from './child-logger.js';
 const PROJECTION_NAME = 'projection';
 const EXTENT_NAME = 'extent';
 const DATATYPE_NAME = 'dataType';
-const BAND_NAME = 'bands';
+const BAND_COUNT_NAME = 'bandCount';
 const FILESIZE_NAME = 'fileSize';
-const NO_DATA_VALUE_NAME = 'noDataValue'
+const NO_DATA_VALUE_NAME = 'noDataValue';
 
 const ALLOWED_PROJECTIONS = ["4326", "3857", "3035"];
 
@@ -47,7 +47,7 @@ class GeotiffValidator {
             PROJECTION_NAME,
             EXTENT_NAME,
             DATATYPE_NAME,
-            BAND_NAME
+            BAND_COUNT_NAME
         ].includes(step)).length;
 
         if (requiresGdalvalidation) {
@@ -76,17 +76,17 @@ class GeotiffValidator {
             switch (step) {
                 case FILESIZE_NAME:
                     return validateFilesize(
-                        filePath, this.config.fileSize.minFileSize, this.config.fileSize.maxFileSize);
+                        filePath, this.config[FILESIZE_NAME].minFileSize, this.config[FILESIZE_NAME].maxFileSize);
                 case PROJECTION_NAME:
-                    return await validateProjection(dataset, this.config.projection.allowedEPSGCodes);
+                    return await validateProjection(dataset, this.config[PROJECTION_NAME].allowedEPSGCodes);
                 case EXTENT_NAME:
-                    return await validateExtent(dataset, boundingExtent(this.config.extent.allowedExtent));
+                    return await validateExtent(dataset, boundingExtent(this.config[EXTENT_NAME].allowedExtent));
                 case DATATYPE_NAME:
-                    return await validateDataType(dataset, this.config.dataType.allowedDataTypes);
-                case BAND_NAME:
-                    return await validateBands(dataset, this.config.bands.expectedCount);
+                    return await validateDataType(dataset, this.config[DATATYPE_NAME].allowedDataTypes);
+                case BAND_COUNT_NAME:
+                    return await validateBandCount(dataset, this.config[BAND_COUNT_NAME].expectedCount);
                 case NO_DATA_VALUE_NAME:
-                    return await validateNoDataValue(dataset, this.config.noDataValue.expectedValue)
+                    return await validateNoDataValue(dataset, this.config[NO_DATA_VALUE_NAME].expectedValue)
                 default:
                     break;
             }
@@ -256,11 +256,11 @@ const validateDataType = async (dataset, allowedDataTypes) => {
  * @returns {Boolean} result.valid If count of bands equal expected count
  * @returns {String} [result.info] Additional information if validation was not succesful
  */
-const validateBands = async (dataset, expectedCountOfBands) => {
+const validateBandCount = async (dataset, expectedCountOfBands) => {
     const countBands = dataset?.bands?.count();
 
     const result = {
-        type: BAND_NAME,
+        type: BAND_COUNT_NAME,
         valid: false
     };
 
@@ -289,7 +289,7 @@ const validateNoDataValue = async (dataset, expectedNoDataValue) => {
     const valid = noDataValues.every(value => value === expectedNoDataValue);
 
     const result = {
-        type: NO_DATA_VALUE_NAME ,
+        type: NO_DATA_VALUE_NAME,
         valid: false
     };
 
@@ -301,4 +301,4 @@ const validateNoDataValue = async (dataset, expectedNoDataValue) => {
     return result;
 }
 
-export { GeotiffValidator, validateFilesize, validateBands, validateDataType, validateExtent, validateProjection, validateNoDataValue };
+export { GeotiffValidator, validateFilesize, validateBandCount, validateDataType, validateExtent, validateProjection, validateNoDataValue };

--- a/src/geotiff-validator/validator.spec.js
+++ b/src/geotiff-validator/validator.spec.js
@@ -1,16 +1,16 @@
-import { GeotiffValidator, validateFilesize, validateBands, validateDataType, validateExtent, validateProjection, validateNoDataValue } from './validator.js';
+import { GeotiffValidator, validateFilesize, validateBandCount, validateDataType, validateExtent, validateProjection, validateNoDataValue } from './validator.js';
 import gdal from 'gdal-async';
 
 const path = 'src/geotiff-validator/sample_data/sample.tif';
 
 describe('GeotiffValidator', () => {
     it('returns true if GeoTIFF is valid', async () => {
-       const config =  {
+        const config = {
             extent: {
-               allowedExtent: [
+                allowedExtent: [
                     [
-                       1,
-                       1
+                        1,
+                        1
                     ],
                     [
                         89,
@@ -33,7 +33,7 @@ describe('GeotiffValidator', () => {
                 minFileSize: 1000,
                 maxFileSize: 10000000
             },
-            bands: {
+            bandCount: {
                 expectedCount: 4
             },
             noDataValue: {
@@ -41,7 +41,7 @@ describe('GeotiffValidator', () => {
             }
         }
         const geotiffValidator = new GeotiffValidator(config);
-        const result = await geotiffValidator.performValidation(path, ['extent', 'projection', 'dataType', 'fileSize', 'bands', 'noDataValue'])
+        const result = await geotiffValidator.performValidation(path, ['extent', 'projection', 'dataType', 'fileSize', 'bandCount', 'noDataValue'])
         const allStepsAreValid = result.every(stepResult => stepResult.valid)
         expect(allStepsAreValid).toBe(true);
     });
@@ -90,16 +90,16 @@ describe('validateDataType', () => {
     });
 });
 
-describe('validateBands', () => {
+describe('validateBandCount', () => {
     it('returns true on valid band count', async () => {
         const dataset = await gdal.openAsync(path);
-        const result = await validateBands(dataset, 4);
+        const result = await validateBandCount(dataset, 4);
         expect(result.valid).toBe(true);
     });
 
     it('returns false on invalid band count', async () => {
         const dataset = await gdal.openAsync(path);
-        const result = await validateBands(dataset, 1);
+        const result = await validateBandCount(dataset, 1);
         expect(result.valid).toBe(false);
         expect(result.info).toBeDefined();
     });
@@ -127,7 +127,6 @@ describe('validate NoDataValue', () => {
         const dataset = await gdal.openAsync(path);
         const validNoDataValue = 42;
         const result = await validateNoDataValue(dataset, validNoDataValue);
-        console.log(result);
         expect(result.valid).toBe(true);
     });
 


### PR DESCRIPTION
- rename `validateBands` to `validateBandCount`
- use constants instead of hardcoded property names
- formatting