### PR TITLE
Reload GS catalog after publishing new data

### DIFF
--- a/src/geoserver-publish-imagemosaic/index.js
+++ b/src/geoserver-publish-imagemosaic/index.js
@@ -68,6 +68,7 @@ const geoserverPublishImageMosaic = async (workerJob, inputs) => {
     } else {
       newPath = await publishClassicGranule(grc, ws, covStore, coverageToAdd, replaceExistingGranule, newPath, geoserverDataDir);
     }
+    grc.resetReload.reload();
   } catch (error) {
     logger.error(error);
     throw 'Could not add new granule to coverage store.';


### PR DESCRIPTION
This is still untested, but should fix the broken image mosaics after publishing.