### PR TITLE
Add python gdal to reclassify-geotiff worker 

### DIFF
--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y netcat
 
 # build environment needed for installing 'gdal-async'
 RUN apt-get install -y build-essential
-RUN apt-get install python-gdal
 
 # install node
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt install -y nodejs

--- a/src/geotiff-validator/Dockerfile
+++ b/src/geotiff-validator/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y netcat
 
 # build environment needed for installing 'gdal-async'
 RUN apt-get install -y build-essential
+RUN apt-get install python-gdal
 
 # install node
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt install -y nodejs

--- a/src/reclassify-geotiff/Dockerfile
+++ b/src/reclassify-geotiff/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y netcat
 
 # build environment needed for installing 'gdal-async'
 RUN apt-get install -y build-essential
+RUN apt-get install python-gdal
 
 # install node
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt install -y nodejs


### PR DESCRIPTION
Add python-gdal to reclassify-geotiff worker in order to run gdal_calc.py.