### PR TITLE
add python3 to reclassify image

### DIFF
--- a/src/reclassify-geotiff/Dockerfile
+++ b/src/reclassify-geotiff/Dockerfile
@@ -1,6 +1,7 @@
 FROM osgeo/gdal:alpine-small-3.5.3
 
 RUN apk add --update nodejs npm
+RUN apk add python3
 RUN apk add gdal-tools
 
 COPY src/reclassify-geotiff/package.json src/reclassify-geotiff/package-lock.json /home/


### PR DESCRIPTION
Installs python in reclassify-geotiff docker image as it is needed for gdal_calc.py-funtion.