### PR TITLE
Delete temporary files after writing to database

### DIFF
--- a/src/create-contour/index.js
+++ b/src/create-contour/index.js
@@ -94,6 +94,17 @@ const contourLinesWorker = async (workerJob, inputs) => {
         if (client) {
             await client.end();
         }
+        // delete temporary files
+        const filesToDelete = fs.readdirSync('/tmp/')
+        for (const file of filesToDelete) {
+
+            await fs.unlink(file, (err => {
+                if (err) logger.error(err);
+                else {
+                    logger.info('Deleted file:', file)
+                }
+            }));
+        }
     }
 
     workerJob.status = 'success';


### PR DESCRIPTION
Deletes temprarily created contourlines after writing them to the database in the create-contour worker.

Coauthored by
@FritzHoing 